### PR TITLE
task notifies grunt on success using handle returned by grunt.async()

### DIFF
--- a/tasks/lib/HtmlInspector.js
+++ b/tasks/lib/HtmlInspector.js
@@ -60,7 +60,7 @@ _.extend(HtmlInspector.prototype, (function () {
         var self = this,
             options = self.options,
             phantomjs = self.phantomjs,
-            markTaskComplete = this.async(),
+            markTaskComplete = self.async(),
             inject = [];
 
         if (!self.filesSrc) {
@@ -106,6 +106,13 @@ _.extend(HtmlInspector.prototype, (function () {
                 };
             
             }()));
+        }, function allFilesTested(er) {
+            if (er) {
+                markTaskComplete(false);
+            }
+            else {
+                markTaskComplete();
+            }
         });
     }
 


### PR DESCRIPTION
When an asyncronous grunt task ends successfully, it must call the done() callback returned by
grunt.async() with no arguments to notify grunt of its success. This was not done before,
creating issues when grunt-html-inspector would be combined with other grunt tasks in
a composite task. Namely, the tasks following grunt-html-inspector would not run, as
grunt would assumme that grunt-html-inspector failed as the done() callback was never
executed.

Now, this is performed by using the relevant functionality of the async.forEachSeries method.
A unit test has been added that confirms this functionality. In order for the unit test to
function, the function returning a grunt task mock was refactored, to better handle the
`this` reference.
